### PR TITLE
Fix random UniqueId mismatch in HW mode

### DIFF
--- a/tc/sgx/trusted_worker_manager/enclave/kme/ext_work_order_info_kme.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/kme/ext_work_order_info_kme.cpp
@@ -209,17 +209,11 @@ int ExtWorkOrderInfoKME::VerifyAttestationWpe(
     mr_enclave = mr_enclave_bytes;
     mr_signer = mr_signer_bytes;
 
-    uint8_t v_key_hash[SGX_HASH_SIZE] = {0};
-    uint8_t e_key_hash[SGX_HASH_SIZE] = {0};
-    strncpy((char* )e_key_hash,
-        (const char* )expected_report_data.d,
-        SGX_HASH_SIZE);
-    strncpy((char* )v_key_hash,
-        (const char* )expected_report_data.d + SGX_HASH_SIZE,
-        SGX_HASH_SIZE);
-    verification_key_hash = StrToByteArray((char*)v_key_hash);
-    encryption_public_key_hash = StrToByteArray((char*)e_key_hash);
 
+    encryption_public_key_hash = ByteArray(std::begin(expected_report_data.d),
+                                     std::begin(expected_report_data.d)+SGX_HASH_SIZE);
+    verification_key_hash = ByteArray(std::begin(expected_report_data.d)+SGX_HASH_SIZE,
+                                     std::end(expected_report_data.d));
     return result;
 
 }  // ExtWorkOrderInfoKME::VerifyAttestationWpe

--- a/tc/sgx/trusted_worker_manager/enclave/wpe/signup_enclave_wpe.cpp
+++ b/tc/sgx/trusted_worker_manager/enclave/wpe/signup_enclave_wpe.cpp
@@ -231,10 +231,9 @@ void CreateSignupReportDataWPE(const uint8_t* ext_data,
     ComputeSHA256Hash((const char*) ext_data, ext_data_hash);
 
     // Concatenate hash of public encryption key and hash of extended data
-    strncpy((char*)report_data->d,
-        (const char*) enc_key_hash, SGX_HASH_SIZE);
-    strncat((char*)report_data->d,
-        (const char*) ext_data_hash, SGX_HASH_SIZE);
+    memcpy(report_data->d, enc_key_hash, SGX_HASH_SIZE);
+    memcpy((report_data->d) + SGX_HASH_SIZE, ext_data_hash, SGX_HASH_SIZE);
+
 }  // CreateSignupReportDataWPE
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -381,8 +380,8 @@ void CreateReportDataWPE(const char* ext_data,
     ComputeSHA256Hash(ext_data, ext_data_hash);
 
     // Concatenate hash of public encryption key and hash of extended data
-    strncpy((char*)report_data->d,
-        (const char*) enc_key_hash, SGX_HASH_SIZE);
-    strncat((char*)report_data->d,
-        (const char*) ext_data_hash, SGX_HASH_SIZE);
+
+    memcpy(report_data->d, enc_key_hash, SGX_HASH_SIZE);
+    memcpy((report_data->d) + SGX_HASH_SIZE, ext_data_hash, SGX_HASH_SIZE);
+
 }  // CreateReportDataWPE


### PR DESCRIPTION
 - Replace strncpy & stncat with memcpy as the underlying
   Byte array might happen to have a byte which is '\0'
   when interprested as string. Strcat/Strcpy will stop at
   the first '\0' encountered hence causing inconsistencies.
 - While reading report data convert to Byte arrays
   instead of string again for the same reason. Do
   the comparisons of Byte arrays.

Signed-off-by: Rajeev Ranjan <rajeev2.ranjan@intel.com>